### PR TITLE
bug/39: Fixed branch protection creation 

### DIFF
--- a/cmd/consoleColors.go
+++ b/cmd/consoleColors.go
@@ -1,0 +1,6 @@
+package cmd
+
+const consoleColorRed = "\033[31m"
+const consoleColorGreen = "\033[32m"
+const consoleColorYellow = "\033[33m"
+const consoleColorReset = "\033[0m"

--- a/cmd/consoleColors.go
+++ b/cmd/consoleColors.go
@@ -1,6 +1,5 @@
 package cmd
 
 const consoleColorRed = "\033[31m"
-const consoleColorGreen = "\033[32m"
 const consoleColorYellow = "\033[33m"
 const consoleColorReset = "\033[0m"

--- a/cmd/workflowDefinitionParser.go
+++ b/cmd/workflowDefinitionParser.go
@@ -11,6 +11,14 @@ import (
 type WorkflowDefinitionParser struct {
 }
 
+type ValidationError struct {
+	message string
+}
+
+func (validationError ValidationError) Error() string {
+	return validationError.message
+}
+
 func (parser WorkflowDefinitionParser) ParseWorkflowDefinition(content string) (*workflowDefinition, error) {
 	parsedYaml := workflowDefinitionInt{}
 	err := yaml.Unmarshal([]byte(content), &parsedYaml)
@@ -54,7 +62,7 @@ func (parser WorkflowDefinitionParser) fillJobNameParametersForMatrixBuild(jobDe
 			}
 			jobNames = append(jobNames, filledNames...)
 		} else {
-			return nil, fmt.Errorf("multi dimensional matrix github-action jobs with no explicit name are not supported. Please add a name field to the job that combines the matrix parameters into a more readable name. For example \"Build with Go ${{matrix.go}} and Exasol ${{ matrix.db }}\"")
+			return nil, ValidationError{"multi dimensional matrix github-action jobs with no explicit name are not supported. Please add a name field to the job that combines the matrix parameters into a more readable name. For example \"Build with Go ${{matrix.go}} and Exasol ${{ matrix.db }}\""}
 		}
 	}
 	return jobNames, nil
@@ -64,7 +72,7 @@ func (parser WorkflowDefinitionParser) addParametersToJobName(jobName string, pa
 	for _, value := range parameterValues {
 		_, isMap := value.(map[interface{}]interface{})
 		if isMap {
-			return nil, fmt.Errorf("matrix github-action jobs with object parameters and no job name are not supported. Please add a name field to the job that combines the matrix parameters into a more readable name. For example \"Build with Go ${{matrix.go}} and Exasol ${{ matrix.db }}\"")
+			return nil, ValidationError{"matrix github-action jobs with object parameters and no job name are not supported. Please add a name field to the job that combines the matrix parameters into a more readable name. For example \"Build with Go ${{matrix.go}} and Exasol ${{ matrix.db }}\""}
 		}
 		extendedJobName := jobName + " (" + parser.convertValueToString(value) + ")"
 		result = append(result, extendedJobName)

--- a/cmd/workflowDefinitionParser_test.go
+++ b/cmd/workflowDefinitionParser_test.go
@@ -178,3 +178,19 @@ jobs:
 	suite.Contains(definition.JobsNames, "build (1.2)")
 	suite.Contains(definition.JobsNames, "build (2.1)")
 }
+
+func (suite *WorkflowDefinitionParserSuite) TestGetChecksForWorkflowForUnsupportedSyntax() {
+	parser := WorkflowDefinitionParser{}
+	_, err := parser.ParseWorkflowDefinition(`
+name: CI Build
+on:
+  push:
+jobs:
+  build:
+    strategy:
+      matrix:
+        test-path: ${{fromJson(needs.prep-testbed.outputs.matrix)}}
+    runs-on: ubuntu-latest
+`)
+	suite.Assert().Error(err)
+}

--- a/doc/changes/changes_0.1.0.md
+++ b/doc/changes/changes_0.1.0.md
@@ -25,6 +25,7 @@ Code name: Improved GitHub Actions
 * #33: Fixed branch protection rule creation for projects with matrix builds
 * #31: Fixed configure-repo for repositories with no workflows
 * #35: Fixed branch protection creation for repos with float matrix build parameter
+* #39: Fixed branch protection creation for runtime generated matrix builds (printing warning that it's not possible)
 
 ## Refactoring
 


### PR DESCRIPTION
 Fixed branch protection creation for runtime generated matrix builds (printing warning that it's not possible)
Closes #39 